### PR TITLE
Add configurable `lang` attribute to <html> element

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -90,6 +90,7 @@ const IndexPage: React.FunctionComponent<IndexProps> = props => {
   return (
     <IndexLayout className={`${HomePosts}`}>
       <Helmet>
+        <html lang={config.lang} />
         <title>{config.title}</title>
         <meta property="og:site_name" content={config.title} />
         <meta property="og:type" content="website" />

--- a/src/templates/author.tsx
+++ b/src/templates/author.tsx
@@ -118,6 +118,7 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
   return (
     <IndexLayout>
       <Helmet>
+        <html lang={config.lang} />
         <title>
           {author.id} - {config.title}
         </title>

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -217,6 +217,7 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
   return (
     <IndexLayout className="post-template">
       <Helmet>
+        <html lang={config.lang} />
         <title>{post.frontmatter.title}</title>
 
         <meta property="og:site_name" content={config.title} />

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -61,6 +61,7 @@ const Tags: React.FunctionComponent<TagTemplateProps> = props => {
   return (
     <IndexLayout>
       <Helmet>
+        <html lang={config.lang} />
         <title>
           {tag} - {config.title}
         </title>

--- a/src/website-config.ts
+++ b/src/website-config.ts
@@ -4,6 +4,11 @@ export interface WebsiteConfig {
   coverImage: string;
   logo: string;
   /**
+   * Specifying a valid BCP 47 language helps screen readers announce text properly.
+   * See: https://dequeuniversity.com/rules/axe/2.2/valid-lang
+   */
+  lang: string;
+  /**
    * blog full path, no ending slash!
    */
   siteUrl: string;
@@ -28,6 +33,7 @@ const config: WebsiteConfig = {
   description: 'The professional publishing platform',
   coverImage: 'img/blog-cover.jpg',
   logo: 'img/ghost-logo.png',
+  lang: 'en',
   siteUrl: 'https://gatsby-casper.netlify.com',
   facebook: 'https://www.facebook.com/ghost',
   twitter: 'https://twitter.com/tryghost',


### PR DESCRIPTION
Addresses the following issue picked up by the [Lighthouse](https://developers.google.com/web/tools/lighthouse/) Accessibility audit:
- `<html>` element does not have a `[lang]` attribute

See: https://dequeuniversity.com/rules/axe/2.2/html-lang-valid