### PR TITLE
Update text colours to meet WCAG 2.0 AA contrast ratio thresholds

### DIFF
--- a/src/components/PostContent.tsx
+++ b/src/components/PostContent.tsx
@@ -135,7 +135,7 @@ export const PostFullContent = styled.section`
   blockquote {
     margin: 0 0 1.5em;
     padding: 0 1.5em;
-    border-left: #3eb0ef 3px solid;
+    border-left: ${colors.blue} 3px solid;
   }
 
   blockquote p {

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,11 +1,11 @@
 export const colors = {
-  blue: '#3eb0ef',
+  blue: '#0f7dba',
   green: '#a4d037',
   purple: '#ad26b4',
   yellow: '#fecd35',
   red: '#f05230',
   darkgrey: '#15171A',
-  midgrey: '#738a94',
+  midgrey: '#647a83',
   lightgrey: '#c5d2d9',
   whitegrey: '#e5eff5',
   pink: '#fa3a57',


### PR DESCRIPTION
Addresses the following issue picked up by the [Lighthouse](https://developers.google.com/web/tools/lighthouse/) Accessibility audit:
- Background and foreground colors do not have a sufficient contrast ratio.

See: https://dequeuniversity.com/rules/axe/2.2/color-contrast

The affected colours are blue `#3eb0ef` and mid-grey `#738a94`.

These have been adjusted to `#0f7dba` and `#647a83` as recommended at http://accessible-colors.com/