### PR TITLE
Add meta description

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -91,6 +91,7 @@ const IndexPage: React.FunctionComponent<IndexProps> = props => {
     <IndexLayout className={`${HomePosts}`}>
       <Helmet>
         <title>{config.title}</title>
+        <meta name="description" content={config.description} />
         <meta property="og:site_name" content={config.title} />
         <meta property="og:type" content="website" />
         <meta property="og:title" content={config.title} />

--- a/src/templates/author.tsx
+++ b/src/templates/author.tsx
@@ -121,6 +121,7 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
         <title>
           {author.id} - {config.title}
         </title>
+        <meta name="description" content={author.bio} />
         <meta property="og:site_name" content={config.title} />
         <meta property="og:type" content="profile" />
         <meta property="og:title" content={`${author.id} - ${config.title}`} />

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -219,6 +219,7 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
       <Helmet>
         <title>{post.frontmatter.title}</title>
 
+        <meta name="description" content={post.excerpt} />
         <meta property="og:site_name" content={config.title} />
         <meta property="og:type" content="article" />
         <meta property="og:title" content={post.frontmatter.title} />

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -64,6 +64,7 @@ const Tags: React.FunctionComponent<TagTemplateProps> = props => {
         <title>
           {tag} - {config.title}
         </title>
+        <meta name="description" content={tagData && tagData.node ? tagData.node.description : ''} />
         <meta property="og:site_name" content={config.title} />
         <meta property="og:type" content="website" />
         <meta property="og:title" content={`${tag} - ${config.title}`} />


### PR DESCRIPTION
Addresses the following issue picked up by the [Lighthouse](https://developers.google.com/web/tools/lighthouse/) SEO audit:
- Document does not have a meta description

See: https://developers.google.com/web/tools/lighthouse/audits/description
