### PR TITLE
Fix errors in social meta tags

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -108,7 +108,7 @@ const IndexPage: React.FunctionComponent<IndexProps> = props => {
           name="twitter:image"
           content={config.siteUrl + props.data.header.childImageSharp.fluid.src}
         />
-        <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[0]}`} />
+        {config.twitter && <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[1]}`} />}
         <meta property="og:image:width" content={width} />
         <meta property="og:image:height" content={height} />
       </Helmet>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -99,7 +99,7 @@ const IndexPage: React.FunctionComponent<IndexProps> = props => {
         <meta property="og:description" content={config.description} />
         <meta property="og:url" content={config.siteUrl} />
         <meta property="og:image" content={config.siteUrl + props.data.header.childImageSharp.fluid.src} />
-        <meta property="article:publisher" content={config.facebook} />
+        {config.facebook && <meta property="article:publisher" content={config.facebook} />}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={config.title} />
         <meta name="twitter:description" content={config.description} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -98,7 +98,7 @@ const IndexPage: React.FunctionComponent<IndexProps> = props => {
         <meta property="og:title" content={config.title} />
         <meta property="og:description" content={config.description} />
         <meta property="og:url" content={config.siteUrl} />
-        <meta property="og:image" content={props.data.header.childImageSharp.fluid.src} />
+        <meta property="og:image" content={config.siteUrl + props.data.header.childImageSharp.fluid.src} />
         <meta property="article:publisher" content={config.facebook} />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={config.title} />
@@ -106,7 +106,7 @@ const IndexPage: React.FunctionComponent<IndexProps> = props => {
         <meta name="twitter:url" content={config.siteUrl} />
         <meta
           name="twitter:image"
-          content={props.data.header.childImageSharp.fluid.src}
+          content={config.siteUrl + props.data.header.childImageSharp.fluid.src}
         />
         <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[0]}`} />
         <meta property="og:image:width" content={width} />

--- a/src/templates/author.tsx
+++ b/src/templates/author.tsx
@@ -132,11 +132,12 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content={`${author.id} - ${config.title}`} />
         <meta name="twitter:url" content={config.siteUrl + props.pathContext.slug} />
-        <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[0]}`} />
+        {config.twitter && <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[1]}`} />}
+        {config.twitter &&
         <meta
           name="twitter:creator"
-          content={`@${config.twitter.split('https://twitter.com/')[0]}`}
-        />
+          content={`@${config.twitter.split('https://twitter.com/')[1]}`}
+        />}
       </Helmet>
       <Wrapper>
         <header

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -249,11 +249,11 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
         <meta name="twitter:data1" content={post.frontmatter.author.id} />
         <meta name="twitter:label2" content="Filed under" />
         {post.frontmatter.tags && <meta name="twitter:data2" content={post.frontmatter.tags[0]} />}
-        <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[0]}`} />
-        <meta
+        {config.twitter && <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[1]}`} />}
+        {config.twitter && <meta
           name="twitter:creator"
-          content={`@${config.twitter.split('https://twitter.com/')[0]}`}
-        />
+          content={`@${config.twitter.split('https://twitter.com/')[1]}`}
+        />}
         {width && <meta property="og:image:width" content={width} />}
         {height && <meta property="og:image:height" content={height} />}
       </Helmet>

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -236,8 +236,8 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
           <meta property="article:tag" content={post.frontmatter.tags[0]} />
         )}
 
-        <meta property="article:publisher" content={config.facebook} />
-        <meta property="article:author" content={config.facebook} />
+        {config.facebook && <meta property="article:publisher" content={config.facebook} />}
+        {config.facebook && <meta property="article:author" content={config.facebook} />}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={post.frontmatter.title} />
         <meta name="twitter:description" content={post.excerpt} />

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -227,7 +227,7 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
         <meta property="og:description" content={post.excerpt} />
         <meta property="og:url" content={config.siteUrl + props.pathContext.slug} />
         {post.frontmatter.image && (
-          <meta property="og:image" content={post.frontmatter.image.childImageSharp.fluid.src} />
+          <meta property="og:image" content={config.siteUrl + post.frontmatter.image.childImageSharp.fluid.src} />
         )}
         <meta property="article:published_time" content={post.frontmatter.date} />
         {/* not sure if modified time possible */}
@@ -243,7 +243,7 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
         <meta name="twitter:description" content={post.excerpt} />
         <meta name="twitter:url" content={config.siteUrl + props.pathContext.slug} />
         {post.frontmatter.image && (
-          <meta name="twitter:image" content={post.frontmatter.image.childImageSharp.fluid.src} />
+          <meta name="twitter:image" content={config.siteUrl + post.frontmatter.image.childImageSharp.fluid.src} />
         )}
         <meta name="twitter:label1" content="Written by" />
         <meta name="twitter:data1" content={post.frontmatter.author.id} />

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -74,7 +74,7 @@ const Tags: React.FunctionComponent<TagTemplateProps> = props => {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={`${tag} - ${config.title}`} />
         <meta name="twitter:url" content={config.siteUrl + props.pathContext.slug} />
-        <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[0]}`} />
+        {config.twitter && <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[1]}`} />}
       </Helmet>
       <Wrapper>
         <header

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -70,7 +70,7 @@ const Tags: React.FunctionComponent<TagTemplateProps> = props => {
         <meta property="og:type" content="website" />
         <meta property="og:title" content={`${tag} - ${config.title}`} />
         <meta property="og:url" content={config.siteUrl + props.pathContext.slug} />
-        <meta property="article:publisher" content={config.facebook} />
+        {config.facebook && <meta property="article:publisher" content={config.facebook} />}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={`${tag} - ${config.title}`} />
         <meta name="twitter:url" content={config.siteUrl + props.pathContext.slug} />


### PR DESCRIPTION
Use absolute URLs in `twitter:image` and `og:image` meta tags so images display when shared.
Fix split() logic for `twitter:site` and `twitter:creator` meta tags so that content contains username.
Render `twitter:site` and `twitter:creator` meta tags only if `config.twitter` set.
Render `article:publisher` and `article:author` meta tags only if `config.facebook` set.
