### PR TITLE
updated graphql with sort order for Prev/Next posts

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -47,7 +47,10 @@ exports.createPages = async ({ graphql, actions }) => {
 
   const result = await graphql(`
     {
-      allMarkdownRemark(limit: 2000) {
+      allMarkdownRemark(
+        limit: 2000
+        sort: { fields: [frontmatter___date], order: ASC }
+      ) {
         edges {
           node {
             excerpt


### PR DESCRIPTION
The post pages all have a *next* and *previous* post listed at the bottom, however, it doesn't always point to the actual previous or next post.  Added the GraphQL sort (ascending) to build the prev/next index in order.