### PR TITLE
feat(emotion): update emotion contsructs to v10 to support gatsby-plugin-emotion v4

### DIFF
--- a/src/components/AuthorCard.tsx
+++ b/src/components/AuthorCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'gatsby';
 import * as _ from 'lodash';
 import * as React from 'react';
-import styled from '@emotion/styled'
+import styled from '@emotion/styled';
 
 import { colors } from '../styles/colors';
 import { AuthorProfileImage } from '../styles/shared';
@@ -42,7 +42,7 @@ const AuthorCard: React.FunctionComponent<AuthorCardProps> = ({ author }) => {
     <AuthorCardSection>
       {/* TODO: default avatar */}
       {/* TODO: author page url */}
-      <img className={`${AuthorProfileImage}`} src={author.avatar.children[0].fixed.src} alt={author.id} />
+      <img css={AuthorProfileImage} src={author.avatar.children[0].fixed.src} alt={author.id} />
       <AuthorCardContent>
         <AuthorCardName>
           <Link to={`/author/${_.kebabCase(author.id)}/`}>{author.id}</Link>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'gatsby';
 import { setLightness } from 'polished';
 import * as React from 'react';
-import styled from '@emotion/styled'
-import { css } from 'emotion'
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 
 import { colors } from '../styles/colors';
 import { outer, inner } from '../styles/shared';
@@ -67,8 +67,8 @@ const SiteFooterNav = styled.nav`
 
 const Footer: React.FunctionComponent = () => {
   return (
-    <footer className={`${outer} ${SiteFooter}`}>
-      <div className={`${inner} ${SiteFooterContent}`}>
+    <footer css={[outer, SiteFooter]}>
+      <div css={[inner, SiteFooterContent]}>
         <section className="copyright">
           <Link to="/">{config.title}</Link> &copy; {new Date().getFullYear()}
         </section>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -3,8 +3,8 @@ import Img from 'gatsby-image';
 import * as _ from 'lodash';
 import { lighten } from 'polished';
 import * as React from 'react';
-import styled from '@emotion/styled'
-import { css } from 'emotion'
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 
 import { colors } from '../styles/colors';
 import { PageContext } from '../templates/post';
@@ -198,9 +198,12 @@ export interface PostCardProps {
 
 const PostCard: React.FunctionComponent<PostCardProps> = ({ post }) => {
   return (
-    <article className={`post-card ${PostCardStyles} ${!post.frontmatter.image ? 'no-image' : ''}`}>
+    <article
+      className={`post-card ${!post.frontmatter.image ? 'no-image' : ''}`}
+      css={PostCardStyles}
+    >
       {post.frontmatter.image && (
-        <Link className={`${PostCardImageLink} post-card-image-link`} to={post.fields.slug}>
+        <Link className="post-card-image-link" css={PostCardImageLink} to={post.fields.slug}>
           <PostCardImage className="post-card-image">
             {post.frontmatter.image &&
               post.frontmatter.image.childImageSharp.fluid && (
@@ -214,7 +217,7 @@ const PostCard: React.FunctionComponent<PostCardProps> = ({ post }) => {
         </Link>
       )}
       <PostCardContent className="post-card-content">
-        <Link className={`${PostCardContentLink} post-card-content-link`} to={post.fields.slug}>
+        <Link className="post-card-content-link" css={PostCardContentLink} to={post.fields.slug}>
           <header className="post-card-header">
             {post.frontmatter.tags && <PostCardTags>{post.frontmatter.tags[0]}</PostCardTags>}
             <PostCardTitle>{post.frontmatter.title}</PostCardTitle>
@@ -229,12 +232,8 @@ const PostCard: React.FunctionComponent<PostCardProps> = ({ post }) => {
               <AuthorNameTooltip className="author-name-tooltip">
                 {post.frontmatter.author.id}
               </AuthorNameTooltip>
-              <Link
-                className={`${StaticAvatar}`}
-                to={`/author/${_.kebabCase(post.frontmatter.author.id)}/`}
-              >
-                <img
-                  className={`${AuthorProfileImage}`}
+              <Link css={StaticAvatar} to={`/author/${_.kebabCase(post.frontmatter.author.id)}/`}>
+                <AuthorProfileImage
                   src={post.frontmatter.author.avatar.children[0].fixed.src}
                   alt={post.frontmatter.author.id}
                 />

--- a/src/components/PostFullFooterRight.tsx
+++ b/src/components/PostFullFooterRight.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'gatsby';
 import * as _ from 'lodash';
 import * as React from 'react';
-import styled from '@emotion/styled'
-import { css } from 'emotion'
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 import { lighten } from 'polished';
 
 import { colors } from '../styles/colors';
@@ -37,7 +37,7 @@ export interface PostFullFooterRightProps {
 
 const PostFullFooterRight: React.FunctionComponent<PostFullFooterRightProps> = props => (
   <PostFullFooterRightDiv>
-    <Link className={`${AuthorCardButton}`} to={`/author/${_.kebabCase(props.authorId)}/`}>
+    <Link css={AuthorCardButton} to={`/author/${_.kebabCase(props.authorId)}/`}>
       Read More
     </Link>
   </PostFullFooterRightDiv>

--- a/src/components/ReadNextCard.tsx
+++ b/src/components/ReadNextCard.tsx
@@ -1,6 +1,6 @@
 import { Link, StaticQuery, graphql } from 'gatsby';
 import * as React from 'react';
-import styled from '@emotion/styled'
+import styled from '@emotion/styled';
 import * as _ from 'lodash';
 
 import { colors } from '../styles/colors';
@@ -11,8 +11,7 @@ export interface ReadNextCardStylesProps {
   coverImage: string;
 }
 
-const ReadNextCardStyles = styled.article<ReadNextCardStylesProps>(
-  props => `
+const ReadNextCardStyles = styled.article`
   position: relative;
   flex: 1 1 300px;
   display: flex;
@@ -25,7 +24,7 @@ const ReadNextCardStyles = styled.article<ReadNextCardStylesProps>(
   background-size: cover;
   border-radius: 5px;
   box-shadow: rgba(39, 44, 49, 0.06) 8px 14px 38px, rgba(39, 44, 49, 0.03) 1px 3px 8px;
-  background-image: url("${props.coverImage}");
+  background-image: url(${(props: ReadNextCardStylesProps) => props.coverImage});
 
   :before {
     content: "";
@@ -39,8 +38,7 @@ const ReadNextCardStyles = styled.article<ReadNextCardStylesProps>(
     border-radius: 5px;
     backdrop-filter: blur(2px);
   }
-`,
-);
+`;
 
 const ReadNextCardHeader = styled.header`
   position: relative;

--- a/src/components/header/SiteNav.tsx
+++ b/src/components/header/SiteNav.tsx
@@ -2,7 +2,7 @@
 import { Link } from 'gatsby';
 import * as React from 'react';
 import styled from '@emotion/styled';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { SocialLink } from '../../styles/shared';
 import config from '../../website-config';
@@ -136,10 +136,10 @@ class SiteNav extends React.Component<SiteNavProps, SiteNaveState> {
   render() {
     const { isHome = false } = this.props;
     return (
-      <nav className={`${isHome ? HomeNavRaise : ''} ${SiteNavStyles}`}>
+      <nav css={[isHome && HomeNavRaise, SiteNavStyles]}>
         <SiteNavLeft>
           {!isHome && <SiteNavLogo />}
-          <ul className={`${NavStyles}`} role="menu">
+          <ul css={NavStyles} role="menu">
             {/* TODO: mark current nav item - add class nav-current */}
             <li role="menuitem">
               <Link to="/">Home</Link>
@@ -156,7 +156,7 @@ class SiteNav extends React.Component<SiteNavProps, SiteNaveState> {
           <SocialLinks>
             {config.facebook && (
               <a
-                className={`${SocialLink}`}
+                css={SocialLink}
                 href={config.facebook}
                 target="_blank"
                 title="Facebook"
@@ -167,7 +167,7 @@ class SiteNav extends React.Component<SiteNavProps, SiteNaveState> {
             )}
             {config.twitter && (
               <a
-                className={`${SocialLink}`}
+                css={SocialLink}
                 href={config.twitter}
                 title="Twitter"
                 target="_blank"

--- a/src/components/header/SiteNavLogo.tsx
+++ b/src/components/header/SiteNavLogo.tsx
@@ -1,6 +1,6 @@
 import { graphql, Link, StaticQuery } from 'gatsby';
 import * as React from 'react';
-import { css } from 'emotion'
+import { css } from '@emotion/core';
 
 import config from '../../website-config';
 
@@ -49,7 +49,7 @@ const SiteNavLogo = () => (
     `}
     // tslint:disable-next-line:react-this-binding-issue
     render={(data: SiteNavLogoProps) => (
-      <Link className={`${SiteNavLogoStyles} site-nav-logo`} to="/">
+      <Link className="site-nav-logo" css={SiteNavLogoStyles} to="/">
         {data.logo ? (
           <img src={data.logo.childImageSharp.fixed.src} alt={config.title} />
         ) : (

--- a/src/components/subsribe/Subscribe.tsx
+++ b/src/components/subsribe/Subscribe.tsx
@@ -1,7 +1,7 @@
 import { lighten } from 'polished';
 import * as React from 'react';
-import styled from '@emotion/styled'
-import { css } from 'emotion'
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 
 import { colors } from '../../styles/colors';
 import SubscribeForm from './SubscribeForm';
@@ -62,7 +62,7 @@ export interface SubscribeProps {
 const Subscribe: React.FunctionComponent<SubscribeProps> = props => {
   return (
     <SubscribeFormSection>
-      <h3 className={`${SubscribeFormTitle}`}>Subscribe to {props.title}</h3>
+      <h3 css={SubscribeFormTitle}>Subscribe to {props.title}</h3>
       <p>Get the latest posts delivered right to your inbox</p>
       <SubscribeForm />
     </SubscribeFormSection>

--- a/src/components/subsribe/SubscribeForm.tsx
+++ b/src/components/subsribe/SubscribeForm.tsx
@@ -1,7 +1,7 @@
 import { darken, desaturate, lighten, mix } from 'polished';
 import * as React from 'react';
-import styled from '@emotion/styled'
-import { css } from 'emotion'
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 
 import { colors } from '../../styles/colors';
 import config from '../../website-config';
@@ -86,7 +86,7 @@ const FormGroup = styled.div`
 const SubscribeForm: React.FunctionComponent = () => {
   return (
       <form
-        className={`${SubscribeFormStyles}`}
+      css={SubscribeFormStyles}
         action={config.mailchimpAction}
         method="post"
         id="mc-embedded-subscribe-form"

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,4 +1,4 @@
-import { injectGlobal } from 'emotion';
+import { Global, css } from '@emotion/core';
 import { darken, lighten } from 'polished';
 import * as React from 'react';
 import Helmet from 'react-helmet';
@@ -6,490 +6,489 @@ import Helmet from 'react-helmet';
 import { colors } from '../styles/colors';
 // @ts-ignore
 import favicon from '../../src/favicon.ico';
-// tslint:disable-next-line:no-unused-expression
-injectGlobal`
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font: inherit;
-  font-size: 100%;
-  vertical-align: baseline;
-}
-body {
-  line-height: 1;
-}
-ol,
-ul {
-  list-style: none;
-}
-blockquote,
-q {
-  quotes: none;
-}
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
-}
-table {
-  border-spacing: 0;
-  border-collapse: collapse;
-}
-img {
-  max-width: 100%;
-}
-html {
-  box-sizing: border-box;
-  font-family: sans-serif;
-
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-}
-*,
-*:before,
-*:after {
-  box-sizing: inherit;
-}
-a {
-  background-color: transparent;
-}
-a:active,
-a:hover {
-  outline: 0;
-}
-b,
-strong {
-  font-weight: bold;
-}
-i,
-em,
-dfn {
-  font-style: italic;
-}
-h1 {
-  margin: 0.67em 0;
-  font-size: 2em;
-}
-small {
-  font-size: 80%;
-}
-sub,
-sup {
-  position: relative;
-  font-size: 75%;
-  line-height: 0;
-  vertical-align: baseline;
-}
-sup {
-  top: -0.5em;
-}
-sub {
-  bottom: -0.25em;
-}
-img {
-  border: 0;
-}
-svg:not(:root) {
-  overflow: hidden;
-}
-mark {
-  background-color: #fdffb6;
-}
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace;
-  font-size: 1em;
-}
-button,
-input,
-optgroup,
-select,
-textarea {
-  margin: 0; 
-  color: inherit; 
-  font: inherit; 
-}
-button {
-  overflow: visible;
-  border: none;
-}
-button,
-select {
-  text-transform: none;
-}
-button,
-html input[type="button"],
-
-input[type="reset"],
-input[type="submit"] {
-  cursor: pointer; 
-
-  -webkit-appearance: button; 
-}
-button[disabled],
-html input[disabled] {
-  cursor: default;
-}
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  padding: 0;
-  border: 0;
-}
-input {
-  line-height: normal;
-}
-input:focus {
-  outline: none;
-}
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box; 
-  padding: 0; 
-}
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  height: auto;
-}
-input[type="search"] {
-  box-sizing: content-box; 
-
-  -webkit-appearance: textfield; 
-}
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-legend {
-  padding: 0; 
-  border: 0; 
-}
-textarea {
-  overflow: auto;
-}
-table {
-  border-spacing: 0;
-  border-collapse: collapse;
-}
-td,
-th {
-  padding: 0;
-}
-
-html {
-  overflow-x: hidden;
-  overflow-y: scroll;
-  font-size: 62.5%;
-
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-}
-body {
-  overflow-x: hidden;
-  /* color: color(var(--midgrey) l(-25%)); */
-  color: ${darken('0.25', colors.midgrey)};
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  font-size: 1.5rem;
-  line-height: 1.6em;
-  font-weight: 400;
-  font-style: normal;
-  letter-spacing: 0;
-  text-rendering: optimizeLegibility;
-  background: #fff;
-
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -moz-font-feature-settings: "liga" on;
-}
-
-::selection {
-  text-shadow: none;
-  /* background: color(var(--blue) lightness(+30%)); */
-  background: ${lighten('0.3', colors.blue)};
-}
-
-hr {
-  position: relative;
-  display: block;
-  width: 100%;
-  margin: 2.5em 0 3.5em;
-  padding: 0;
-  height: 1px;
-  border: 0;
-  /* border-top: 1px solid color(var(--lightgrey) l(+10%)); */
-  border-top: 1px solid ${lighten('0.1', colors.lightgrey)};
-}
-
-audio,
-canvas,
-iframe,
-img,
-svg,
-video {
-  vertical-align: middle;
-}
-
-fieldset {
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
-textarea {
-  resize: vertical;
-}
-
-p,
-ul,
-ol,
-dl,
-blockquote {
-  margin: 0 0 1.5em 0;
-}
-
-ol,
-ul {
-  padding-left: 1.3em;
-  padding-right: 1.5em;
-}
-
-ol ol,
-ul ul,
-ul ol,
-ol ul {
-  margin: 0.5em 0 1em;
-}
-
-ul {
-  list-style: disc;
-}
-
-ol {
-  list-style: decimal;
-}
-
-ul,
-ol {
-  max-width: 100%;
-}
-
-li {
-  margin: 0.5em 0;
-  padding-left: 0.3em;
-  line-height: 1.6em;
-}
-
-dt {
-  float: left;
-  margin: 0 20px 0 0;
-  width: 120px;
-  color: ${colors.darkgrey};
-  font-weight: 500;
-  text-align: right;
-}
-
-dd {
-  margin: 0 0 5px 0;
-  text-align: left;
-}
-
-blockquote {
-  margin: 1.5em 0;
-  padding: 0 1.6em 0 1.6em;
-  border-left: ${colors.whitegrey} 0.5em solid;
-}
-
-blockquote p {
-  margin: 0.8em 0;
-  font-size: 1.2em;
-  font-weight: 300;
-}
-
-blockquote small {
-  display: inline-block;
-  margin: 0.8em 0 0.8em 1.5em;
-  font-size: 0.9em;
-  opacity: 0.8;
-}
-
-blockquote small:before {
-  content: "\\2014 \\00A0";
-}
-
-blockquote cite {
-  font-weight: bold;
-}
-blockquote cite a {
-  font-weight: normal;
-}
-
-a {
-  /* color: color(var(--blue) l(-5%)); */
-  color: ${darken('0.05', colors.blue)};
-  text-decoration: none;
-}
-
-a:hover {
-  text-decoration: underline;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  margin-top: 0;
-  line-height: 1.15;
-  font-weight: 700;
-  text-rendering: optimizeLegibility;
-}
-
-h1 {
-  margin: 0 0 0.5em 0;
-  font-size: 5rem;
-  font-weight: 700;
-}
-@media (max-width: 500px) {
-  h1 {
-      font-size: 2.2rem;
-  }
-}
-
-h2 {
-  margin: 1.5em 0 0.5em 0;
-  font-size: 2rem;
-}
-@media (max-width: 500px) {
-  h2 {
-      font-size: 1.8rem;
-  }
-}
-
-h3 {
-  margin: 1.5em 0 0.5em 0;
-  font-size: 1.8rem;
-  font-weight: 500;
-}
-@media (max-width: 500px) {
-  h3 {
-      font-size: 1.7rem;
-  }
-}
-
-h4 {
-  margin: 1.5em 0 0.5em 0;
-  font-size: 1.6rem;
-  font-weight: 500;
-}
-
-h5 {
-  margin: 1.5em 0 0.5em 0;
-  font-size: 1.4rem;
-  font-weight: 500;
-}
-
-h6 {
-  margin: 1.5em 0 0.5em 0;
-  font-size: 1.4rem;
-  font-weight: 500;
-}
-
-body {
-  background: #f4f8fb;
-}
-`;
 
 interface IndexProps {
   className?: string;
 }
 
+const GlobalStyles = css`
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font: inherit;
+    font-size: 100%;
+    vertical-align: baseline;
+  }
+  body {
+    line-height: 1;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  blockquote,
+  q {
+    quotes: none;
+  }
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: '';
+    content: none;
+  }
+  table {
+    border-spacing: 0;
+    border-collapse: collapse;
+  }
+  img {
+    max-width: 100%;
+  }
+  html {
+    box-sizing: border-box;
+    font-family: sans-serif;
+
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
+  }
+  *,
+  *:before,
+  *:after {
+    box-sizing: inherit;
+  }
+  a {
+    background-color: transparent;
+  }
+  a:active,
+  a:hover {
+    outline: 0;
+  }
+  b,
+  strong {
+    font-weight: bold;
+  }
+  i,
+  em,
+  dfn {
+    font-style: italic;
+  }
+  h1 {
+    margin: 0.67em 0;
+    font-size: 2em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub,
+  sup {
+    position: relative;
+    font-size: 75%;
+    line-height: 0;
+    vertical-align: baseline;
+  }
+  sup {
+    top: -0.5em;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  img {
+    border: 0;
+  }
+  svg:not(:root) {
+    overflow: hidden;
+  }
+  mark {
+    background-color: #fdffb6;
+  }
+  code,
+  kbd,
+  pre,
+  samp {
+    font-family: monospace, monospace;
+    font-size: 1em;
+  }
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    margin: 0;
+    color: inherit;
+    font: inherit;
+  }
+  button {
+    overflow: visible;
+    border: none;
+  }
+  button,
+  select {
+    text-transform: none;
+  }
+  button,
+  html input[type='button'],
+  input[type='reset'],
+  input[type='submit'] {
+    cursor: pointer;
+
+    -webkit-appearance: button;
+  }
+  button[disabled],
+  html input[disabled] {
+    cursor: default;
+  }
+  button::-moz-focus-inner,
+  input::-moz-focus-inner {
+    padding: 0;
+    border: 0;
+  }
+  input {
+    line-height: normal;
+  }
+  input:focus {
+    outline: none;
+  }
+  input[type='checkbox'],
+  input[type='radio'] {
+    box-sizing: border-box;
+    padding: 0;
+  }
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    height: auto;
+  }
+  input[type='search'] {
+    box-sizing: content-box;
+
+    -webkit-appearance: textfield;
+  }
+  input[type='search']::-webkit-search-cancel-button,
+  input[type='search']::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  legend {
+    padding: 0;
+    border: 0;
+  }
+  textarea {
+    overflow: auto;
+  }
+  table {
+    border-spacing: 0;
+    border-collapse: collapse;
+  }
+  td,
+  th {
+    padding: 0;
+  }
+
+  html {
+    overflow-x: hidden;
+    overflow-y: scroll;
+    font-size: 62.5%;
+
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  }
+  body {
+    overflow-x: hidden;
+    color: ${darken('0.25', colors.midgrey)};
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+      'Open Sans', 'Helvetica Neue', sans-serif;
+    font-size: 1.5rem;
+    line-height: 1.6em;
+    font-weight: 400;
+    font-style: normal;
+    letter-spacing: 0;
+    text-rendering: optimizeLegibility;
+    background: #fff;
+
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -moz-font-feature-settings: 'liga' on;
+  }
+
+  ::selection {
+    text-shadow: none;
+    background: ${lighten('0.3', colors.blue)};
+  }
+
+  hr {
+    position: relative;
+    display: block;
+    width: 100%;
+    margin: 2.5em 0 3.5em;
+    padding: 0;
+    height: 1px;
+    border: 0;
+    border-top: 1px solid ${lighten('0.1', colors.lightgrey)};
+  }
+
+  audio,
+  canvas,
+  iframe,
+  img,
+  svg,
+  video {
+    vertical-align: middle;
+  }
+
+  fieldset {
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  p,
+  ul,
+  ol,
+  dl,
+  blockquote {
+    margin: 0 0 1.5em 0;
+  }
+
+  ol,
+  ul {
+    padding-left: 1.3em;
+    padding-right: 1.5em;
+  }
+
+  ol ol,
+  ul ul,
+  ul ol,
+  ol ul {
+    margin: 0.5em 0 1em;
+  }
+
+  ul {
+    list-style: disc;
+  }
+
+  ol {
+    list-style: decimal;
+  }
+
+  ul,
+  ol {
+    max-width: 100%;
+  }
+
+  li {
+    margin: 0.5em 0;
+    padding-left: 0.3em;
+    line-height: 1.6em;
+  }
+
+  dt {
+    float: left;
+    margin: 0 20px 0 0;
+    width: 120px;
+    color: ${colors.darkgrey};
+    font-weight: 500;
+    text-align: right;
+  }
+
+  dd {
+    margin: 0 0 5px 0;
+    text-align: left;
+  }
+
+  blockquote {
+    margin: 1.5em 0;
+    padding: 0 1.6em 0 1.6em;
+    border-left: ${colors.whitegrey} 0.5em solid;
+  }
+
+  blockquote p {
+    margin: 0.8em 0;
+    font-size: 1.2em;
+    font-weight: 300;
+  }
+
+  blockquote small {
+    display: inline-block;
+    margin: 0.8em 0 0.8em 1.5em;
+    font-size: 0.9em;
+    opacity: 0.8;
+  }
+
+  blockquote small:before {
+    content: '\\2014 \\00A0';
+  }
+
+  blockquote cite {
+    font-weight: bold;
+  }
+  blockquote cite a {
+    font-weight: normal;
+  }
+
+  a {
+    color: ${darken('0.05', colors.blue)};
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-top: 0;
+    line-height: 1.15;
+    font-weight: 700;
+    text-rendering: optimizeLegibility;
+  }
+
+  h1 {
+    margin: 0 0 0.5em 0;
+    font-size: 5rem;
+    font-weight: 700;
+  }
+  @media (max-width: 500px) {
+    h1 {
+      font-size: 2.2rem;
+    }
+  }
+
+  h2 {
+    margin: 1.5em 0 0.5em 0;
+    font-size: 2rem;
+  }
+  @media (max-width: 500px) {
+    h2 {
+      font-size: 1.8rem;
+    }
+  }
+
+  h3 {
+    margin: 1.5em 0 0.5em 0;
+    font-size: 1.8rem;
+    font-weight: 500;
+  }
+  @media (max-width: 500px) {
+    h3 {
+      font-size: 1.7rem;
+    }
+  }
+
+  h4 {
+    margin: 1.5em 0 0.5em 0;
+    font-size: 1.6rem;
+    font-weight: 500;
+  }
+
+  h5 {
+    margin: 1.5em 0 0.5em 0;
+    font-size: 1.4rem;
+    font-weight: 500;
+  }
+
+  h6 {
+    margin: 1.5em 0 0.5em 0;
+    font-size: 1.4rem;
+    font-weight: 500;
+  }
+
+  body {
+    background: #f4f8fb;
+  }
+`;
+
 const IndexLayout: React.FunctionComponent<IndexProps> = props => {
-  return <div className={props.className}>
-    <Helmet>
-      <link rel="icon" href={favicon} type="image/x-icon" />
-    </Helmet>
-    {props.children}
-  </div>;
+  return (
+    <div className={props.className}>
+      <Helmet>
+        <link rel="icon" href={favicon} type="image/x-icon" />
+      </Helmet>
+      <Global styles={GlobalStyles} />
+      {props.children}
+    </div>
+  );
 };
 
 export default IndexLayout;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import { graphql, Link } from 'gatsby';
 import * as React from 'react';
-import styled from '@emotion/styled'
-import { css } from 'emotion'
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 
 import SiteNavLogo from '../components/header/SiteNavLogo';
 import PostCard from '../components/PostCard';
@@ -64,27 +64,27 @@ const NotFoundPage: React.FunctionComponent<NotFoundTemplateProps> = props => {
   return (
     <IndexLayout>
       <Wrapper>
-        <header className={`${SiteHeader} ${outer}`}>
+        <header css={[SiteHeader, outer]}>
           <div className="inner">
             <SiteNavCenter>
               <SiteNavLogo />
             </SiteNavCenter>
           </div>
         </header>
-        <main id="site-main" className={`${ErrorTemplate} ${outer}`}>
-          <div className={`${inner}`}>
+        <main id="site-main" css={[ErrorTemplate, outer]}>
+          <div css={inner}>
             <section style={{ textAlign: 'center' }}>
               <ErrorCode>404</ErrorCode>
               <ErrorDescription>Page not found</ErrorDescription>
-              <Link className={`${ErrorLink}`} to={''}>
+              <Link css={ErrorLink} to={''}>
                 Go to the front page →
               </Link>
             </section>
           </div>
         </main>
-        <aside className={`${outer}`}>
-          <div className={`${inner}`}>
-            <div className={`${PostFeed}`}>
+        <aside css={outer}>
+          <div css={inner}>
+            <div css={PostFeed}>
               {edges.map(({ node }) => (
                 <PostCard key={node.fields.slug} post={node} />
               ))}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -3,7 +3,7 @@ import Wrapper from '../components/Wrapper';
 import SiteNav from '../components/header/SiteNav';
 import { SiteHeader, outer, inner, SiteMain } from '../styles/shared';
 import * as React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { PostFullHeader, PostFullTitle, NoImage, PostFull } from '../templates/post';
 import { PostFullContent } from '../components/PostContent';
@@ -23,14 +23,14 @@ const About: React.FunctionComponent = () => (
     <Helmet>
       <title>About</title>
     </Helmet>
-    <Wrapper className={`${PageTemplate}`}>
-      <header className={`${SiteHeader} ${outer}`}>
-        <div className={`${inner}`}>
+    <Wrapper css={PageTemplate}>
+      <header css={[outer, SiteHeader]}>
+        <div css={inner}>
           <SiteNav />
         </div>
       </header>
-      <main id="site-main" className={`site-main ${SiteMain} ${outer}`}>
-        <article className={`${PostFull} post page ${NoImage}`}>
+      <main id="site-main" className="site-main" css={[SiteMain, outer]}>
+        <article className="post page" css={[PostFull, NoImage]}>
           <PostFullHeader>
             <PostFullTitle>About</PostFullTitle>
           </PostFullHeader>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { graphql } from 'gatsby';
 import * as React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 import Helmet from 'react-helmet';
 
 import Footer from '../components/Footer';
@@ -88,7 +88,7 @@ const IndexPage: React.FunctionComponent<IndexProps> = props => {
   const width = props.data.header.childImageSharp.fluid.sizes.split(', ')[1].split('px')[0];
   const height = String(Number(width) / props.data.header.childImageSharp.fluid.aspectRatio);
   return (
-    <IndexLayout className={`${HomePosts}`}>
+    <IndexLayout css={HomePosts}>
       <Helmet>
         <html lang={config.lang} />
         <title>{config.title}</title>
@@ -122,12 +122,12 @@ const IndexPage: React.FunctionComponent<IndexProps> = props => {
       </Helmet>
       <Wrapper>
         <header
-          className={`${SiteHeader} ${outer}`}
+          css={[outer, SiteHeader]}
           style={{
             backgroundImage: `url('${props.data.header.childImageSharp.fluid.src}')`,
           }}
         >
-          <div className={`${inner}`}>
+          <div css={inner}>
             <SiteHeaderContent>
               <SiteTitle>
                 {props.data.logo ? (
@@ -145,9 +145,9 @@ const IndexPage: React.FunctionComponent<IndexProps> = props => {
             <SiteNav isHome={true} />
           </div>
         </header>
-        <main id="site-main" className={`${SiteMain} ${outer}`}>
-          <div className={`${inner}`}>
-            <div className={`${PostFeed} ${PostFeedRaise}`}>
+        <main id="site-main" css={[SiteMain, outer]}>
+          <div css={inner}>
+            <div css={[PostFeed, PostFeedRaise]}>
               {props.data.allMarkdownRemark.edges.map(post => {
                 // filter out drafts in production
                 return (

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled'
 import { colors } from './colors';
 import { darken, lighten } from 'polished';

--- a/src/templates/author.tsx
+++ b/src/templates/author.tsx
@@ -1,7 +1,7 @@
 import { graphql } from 'gatsby';
 import React from 'react';
 import styled from '@emotion/styled';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import Footer from '../components/Footer';
 import SiteNav from '../components/header/SiteNav';
@@ -155,18 +155,19 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
       </Helmet>
       <Wrapper>
         <header
-          className={`${SiteHeader} ${outer} no-cover`}
+          className="no-cover"
+          css={[outer, SiteHeader]}
           style={{
             backgroundImage: author.profile_image
               ? `url(${author.profile_image.childImageSharp.fluid.src})`
               : '',
           }}
         >
-          <div className={`${inner}`}>
+          <div css={inner}>
             <SiteNav isHome={false} />
             <SiteHeaderContent>
               <img
-                className={`${AuthorProfileBioImage} ${AuthorProfileImage}`}
+                css={[AuthorProfileImage, AuthorProfileBioImage]}
                 src={props.data.authorYaml.avatar.childImageSharp.fluid.src}
                 alt={author.id}
               />
@@ -174,11 +175,11 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
               {author.bio && <AuthorBio>{author.bio}</AuthorBio>}
               <AuthorMeta>
                 {author.location && (
-                  <div className={`${HiddenMobile}`}>
+                  <div css={HiddenMobile}>
                     {author.location} <Bull>&bull;</Bull>
                   </div>
                 )}
-                <div className={`${HiddenMobile}`}>
+                <div css={HiddenMobile}>
                   {totalCount > 1 && `${totalCount} posts`}
                   {totalCount === 1 && `1 post`}
                   {totalCount === 0 && `No posts`} <Bull>•</Bull>
@@ -186,7 +187,8 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
                 {author.website && (
                   <div>
                     <a
-                      className={`${SocialLink} social-link-wb`}
+                      className="social-link-wb"
+                      css={SocialLink}
                       href={author.website}
                       title="Website"
                       target="_blank"
@@ -198,7 +200,8 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
                 )}
                 {author.twitter && (
                   <a
-                    className={`${SocialLink} social-link-tw`}
+                    className="social-link-tw"
+                    css={SocialLink}
                     href={`https://twitter.com/${author.twitter}`}
                     title="Twitter"
                     target="_blank"
@@ -209,7 +212,8 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
                 )}
                 {author.facebook && (
                   <a
-                    className={`${SocialLink} social-link-fb`}
+                    className="social-link-fb"
+                    css={SocialLink}
                     href={`https://www.facebook.com/${author.facebook}`}
                     title="Facebook"
                     target="_blank"
@@ -220,7 +224,7 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
                 )}
                 {/* TODO: RSS for author */}
                 {/* <a
-                  className={`${SocialLink} social-link-rss`}
+                  css={SocialLink} className="social-link-rss"
                   href="https://feedly.com/i/subscription/feed/https://demo.ghost.io/author/ghost/rss/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -238,9 +242,9 @@ const Author: React.FunctionComponent<AuthorTemplateProps> = props => {
             </SiteHeaderContent>
           </div>
         </header>
-        <main id="site-main" className={`${SiteMain} ${outer}`}>
-          <div className={`${inner}`}>
-            <div className={`${PostFeed} ${PostFeedRaise}`}>
+        <main id="site-main" css={[SiteMain, outer]}>
+          <div css={inner}>
+            <div css={[PostFeed, PostFeedRaise]}>
               {edges.map(({ node }) => {
                 return <PostCard key={node.fields.slug} post={node} />;
               })}

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -3,8 +3,8 @@ import Img from 'gatsby-image';
 import * as _ from 'lodash';
 import { setLightness } from 'polished';
 import * as React from 'react';
-import styled from '@emotion/styled'
-import { css } from 'emotion'
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 import { Helmet } from 'react-helmet';
 
 import AuthorCard from '../components/AuthorCard';
@@ -24,7 +24,7 @@ import config from '../website-config';
 
 const PostTemplate = css`
   .site-main {
-    background #fff;
+    background: #fff;
     padding-bottom: 4vw;
   }
 `;
@@ -258,16 +258,16 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
         {width && <meta property="og:image:width" content={width} />}
         {height && <meta property="og:image:height" content={height} />}
       </Helmet>
-      <Wrapper className={`${PostTemplate}`}>
-        <header className={`${SiteHeader} ${outer}`}>
-          <div className={`${inner}`}>
+      <Wrapper css={PostTemplate}>
+        <header css={[outer, SiteHeader]}>
+          <div css={inner}>
             <SiteNav />
           </div>
         </header>
-        <main id="site-main" className={`site-main ${SiteMain} ${outer}`}>
-          <div className={`${inner}`}>
+        <main id="site-main" className="site-main" css={[SiteMain, outer]}>
+          <div css={inner}>
             {/* TODO: no-image css tag? */}
-            <article className={`${PostFull} ${!post.frontmatter.image ? NoImage : ''}`}>
+            <article css={[PostFull, !post.frontmatter.image && NoImage]}>
               <PostFullHeader>
                 <PostFullMeta>
                   <PostFullMetaDate dateTime={post.frontmatter.date}>
@@ -308,8 +308,8 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
         </main>
 
         {/* Links to Previous/Next posts */}
-        <aside className={`read-next ${outer}`}>
-          <div className={`${inner}`}>
+        <aside className="read-next" css={outer}>
+          <div css={inner}>
             <ReadNextFeed>
               {props.data.relatedPosts && (
                 <ReadNextCard tags={post.frontmatter.tags} relatedPosts={props.data.relatedPosts} />

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -65,7 +65,10 @@ const Tags: React.FunctionComponent<TagTemplateProps> = props => {
         <title>
           {tag} - {config.title}
         </title>
-        <meta name="description" content={tagData && tagData.node ? tagData.node.description : ''} />
+        <meta
+          name="description"
+          content={tagData && tagData.node ? tagData.node.description : ''}
+        />
         <meta property="og:site_name" content={config.title} />
         <meta property="og:type" content="website" />
         <meta property="og:title" content={`${tag} - ${config.title}`} />
@@ -74,11 +77,17 @@ const Tags: React.FunctionComponent<TagTemplateProps> = props => {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={`${tag} - ${config.title}`} />
         <meta name="twitter:url" content={config.siteUrl + props.pathContext.slug} />
-        {config.twitter && <meta name="twitter:site" content={`@${config.twitter.split('https://twitter.com/')[1]}`} />}
+        {config.twitter && (
+          <meta
+            name="twitter:site"
+            content={`@${config.twitter.split('https://twitter.com/')[1]}`}
+          />
+        )}
       </Helmet>
       <Wrapper>
         <header
-          className={`${SiteHeader} ${outer} ${tagData && tagData.node.image ? '' : 'no-cover'}`}
+          className={`${tagData && tagData.node.image ? '' : 'no-cover'}`}
+          css={[outer, SiteHeader]}
           style={{
             backgroundImage:
               tagData && tagData.node.image
@@ -86,7 +95,7 @@ const Tags: React.FunctionComponent<TagTemplateProps> = props => {
                 : '',
           }}
         >
-          <div className={`${inner}`}>
+          <div css={inner}>
             <SiteNav isHome={false} />
             <SiteHeaderContent>
               <SiteTitle>{tag}</SiteTitle>
@@ -104,9 +113,9 @@ const Tags: React.FunctionComponent<TagTemplateProps> = props => {
             </SiteHeaderContent>
           </div>
         </header>
-        <main id="site-main" className={`${SiteMain} ${outer}`}>
-          <div className={`${inner}`}>
-            <div className={`${PostFeed} ${PostFeedRaise}`}>
+        <main id="site-main" css={[SiteMain, outer]}>
+          <div css={inner}>
+            <div css={[PostFeed, PostFeedRaise]}>
               {edges.map(({ node }) => (
                 <PostCard key={node.fields.slug} post={node} />
               ))}


### PR DESCRIPTION
This fixes issue #25 

I realized `gatsby-plugin-emotion` **v4.x** supports `@emotion/core` which is **v10.x** . We are currently using `emotion`  which is **v9.x** 

So going through the [migration document](https://github.com/emotion-js/emotion/blob/master/docs/migrating-to-emotion-10.md) on `emotion-js` repository. I have changed the following constructs:
1. From `emotion` to `@emotion/core`

    ```js
    import { css } from 'emotion'
    // to
    import { css } from '@emotion/core'
    ```
2. I have removed `injectGlobal ` and replaced with `Global` as stated [here](https://www.gatsbyjs.org/docs/creating-global-styles/#how-to-add-global-styles-in-gatsby-using-css-in-js)

    ```js
    import { Global } from "@emotion/core"
    ```
3. I used [The css Prop](https://emotion.sh/docs/css-prop)

   ```
   <img className={`${AuthorProfileImage}`} />
   //
   <img css={AuthorProfileImage} />
   ```

closes #25 