### PR TITLE
Fixes null references for featured images and tags

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -206,6 +206,7 @@ const PostCard: React.FunctionComponent<PostCardProps> = ({ post }) => {
         <Link className="post-card-image-link" css={PostCardImageLink} to={post.fields.slug}>
           <PostCardImage className="post-card-image">
             {post.frontmatter.image &&
+              post.frontmatter.image.childImageSharp &&
               post.frontmatter.image.childImageSharp.fluid && (
                 <Img
                   alt={`${post.frontmatter.title} cover image`}

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -210,7 +210,7 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
   const post = props.data.markdownRemark;
   let width = '';
   let height = '';
-  if (post.frontmatter.image) {
+  if (post.frontmatter.image && post.frontmatter.image.childImageSharp) {
     width = post.frontmatter.image.childImageSharp.fluid.sizes.split(', ')[1].split('px')[0];
     height = String(Number(width) / post.frontmatter.image.childImageSharp.fluid.aspectRatio);
   }
@@ -227,7 +227,7 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
         <meta property="og:title" content={post.frontmatter.title} />
         <meta property="og:description" content={post.excerpt} />
         <meta property="og:url" content={config.siteUrl + props.pathContext.slug} />
-        {post.frontmatter.image && (
+        {(post.frontmatter.image && post.frontmatter.image.childImageSharp) && (
           <meta property="og:image" content={`${config.siteUrl}${post.frontmatter.image.childImageSharp.fluid.src}`} />
         )}
         <meta property="article:published_time" content={post.frontmatter.date} />
@@ -243,7 +243,7 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
         <meta name="twitter:title" content={post.frontmatter.title} />
         <meta name="twitter:description" content={post.excerpt} />
         <meta name="twitter:url" content={config.siteUrl + props.pathContext.slug} />
-        {post.frontmatter.image && (
+        {(post.frontmatter.image && post.frontmatter.image.childImageSharp)&& (
           <meta name="twitter:image" content={`${config.siteUrl}${post.frontmatter.image.childImageSharp.fluid.src}`} />
         )}
         <meta name="twitter:label1" content="Written by" />
@@ -286,7 +286,7 @@ const PageTemplate: React.FunctionComponent<PageTemplateProps> = props => {
                 <PostFullTitle>{post.frontmatter.title}</PostFullTitle>
               </PostFullHeader>
 
-              {post.frontmatter.image && (
+              {(post.frontmatter.image && post.frontmatter.image.childImageSharp) && (
                 <PostFullImage>
                   <Img
                     style={{ height: '100%' }}

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -52,7 +52,7 @@ interface TagTemplateProps {
 }
 
 const Tags: React.FunctionComponent<TagTemplateProps> = props => {
-  const tag = props.pageContext.tag;
+  const tag = (props.pageContext.tag) ? props.pageContext.tag : "";
   const { edges, totalCount } = props.data.allMarkdownRemark;
   const tagData = props.data.allTagYaml.edges.find(
     n => n.node.id.toLowerCase() === tag.toLowerCase(),


### PR DESCRIPTION
I recently started migrating from Wordpress to Gatsby. The export of my 10 years of content turned up a few issues where I had some posts with no featured image and no tag information. This PR adds some simple null checks to make sure those are available, and if not it will just render the post title/leave out the image and tag information.