### PR TITLE
Modified line 217 of post.tsx so that it matches what is shown on landing page

### DIFF
--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -214,7 +214,7 @@ const PageTemplate: React.FC<PageTemplateProps> = props => {
                           {displayDatetime}
                         </time>
                         <span className="byline-reading-time">
-                          <span className="bull">&bull;</span> 20 min read
+                          <span className="bull">&bull;</span> {post.timeToRead} min read
                         </span>
                       </div>
                     </section>
@@ -481,15 +481,9 @@ export const query = graphql`
       }
     }
     relatedPosts: allMarkdownRemark(
-      filter: {
-        frontmatter: { tags: { in: [$primaryTag] },
-        draft: { ne: true } }
-      }
+      filter: { frontmatter: { tags: { in: [$primaryTag] }, draft: { ne: true } } }
       limit: 5
-      sort: {
-        fields: [frontmatter___date]
-        order: DESC
-      }
+      sort: { fields: [frontmatter___date], order: DESC }
     ) {
       totalCount
       edges {


### PR DESCRIPTION
On line 217 of the post.tsx file in the template folder, the following line is hard coded so that once you click into a blog post, it will always show the estimated time to read as 20 mins. The landing page will show the accurate time to read for blog posts, so I made a small tweak here to fix this.