### PR TITLE
Show All Post Tags (config flag)

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -51,11 +51,12 @@ export const PostCard: React.FC<PostCardProps> = ({ post, large = false }) => {
               <PostCardPrimaryTag className="post-card-primary-tag">
                 {post.frontmatter.tags.map(
                   function(t){
-                    return (
+                    return ([
                       <Link to={`/tags/${_.kebabCase(t)}/`}>
-                        {t}&nbsp;
-                      </Link>
-                    )
+                        {t}
+                      </Link>,
+                      <b>&nbsp;</b>,
+                    ])
                   }
                 )}
               </PostCardPrimaryTag>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -11,6 +11,7 @@ import styled from '@emotion/styled';
 import { colors } from '../styles/colors';
 import { PageContext } from '../templates/post';
 import { AuthorList } from './AuthorList';
+import config from '../website-config';
 
 export interface PostCardProps {
   post: PageContext;
@@ -46,7 +47,7 @@ export const PostCard: React.FC<PostCardProps> = ({ post, large = false }) => {
       <PostCardContent className="post-card-content">
         <Link className="post-card-content-link" css={PostCardContentLink} to={post.fields.slug}>
           <PostCardHeader className="post-card-header">
-            {post.frontmatter.tags && (
+            {post.frontmatter.tags && config.showAllTags && (
               <PostCardPrimaryTag className="post-card-primary-tag">
                 {post.frontmatter.tags.map(
                   function(t){
@@ -57,6 +58,13 @@ export const PostCard: React.FC<PostCardProps> = ({ post, large = false }) => {
                     )
                   }
                 )}
+              </PostCardPrimaryTag>
+            )}
+            {post.frontmatter.tags && !config.showAllTags && (
+              <PostCardPrimaryTag className="post-card-primary-tag">
+                <Link to={`/tags/${_.kebabCase(post.frontmatter.tags[0])}/`}>
+                  {post.frontmatter.tags[0]}
+                </Link>
               </PostCardPrimaryTag>
             )}
             <PostCardTitle className="post-card-title">{post.frontmatter.title}</PostCardTitle>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -48,9 +48,15 @@ export const PostCard: React.FC<PostCardProps> = ({ post, large = false }) => {
           <PostCardHeader className="post-card-header">
             {post.frontmatter.tags && (
               <PostCardPrimaryTag className="post-card-primary-tag">
-                <Link to={`/tags/${_.kebabCase(post.frontmatter.tags[0])}/`}>
-                  {post.frontmatter.tags[0]}
-                </Link>
+                {post.frontmatter.tags.map(
+                  function(t){
+                    return (
+                      <Link to={`/tags/${_.kebabCase(t)}/`}>
+                        {t}&nbsp;
+                      </Link>
+                    )
+                  }
+                )}
               </PostCardPrimaryTag>
             )}
             <PostCardTitle className="post-card-title">{post.frontmatter.title}</PostCardTitle>

--- a/src/content/a-full-style-test.md
+++ b/src/content/a-full-style-test.md
@@ -6,6 +6,7 @@ author: [Ghost]
 date: 2018-09-30T07:03:47.149Z
 tags:
   - Tests
+  - Getting Started
 ---
 
 Below is just about everything you’ll need to style in the theme. Check the source code to see the many embedded elements within paragraphs.

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -193,9 +193,15 @@ const PageTemplate = ({ data, pageContext, location }: PageTemplateProps) => {
               <PostFullHeader className="post-full-header">
                 <PostFullTags className="post-full-tags">
                   {post.frontmatter.tags && post.frontmatter.tags.length > 0 && (
-                    <Link to={`/tags/${_.kebabCase(post.frontmatter.tags[0])}/`}>
-                      {post.frontmatter.tags[0]}
-                    </Link>
+                    post.frontmatter.tags.map(
+                      function(t){
+                        return (
+                          <Link to={`/tags/${_.kebabCase(t)}/`}>
+                            {t}&nbsp; 
+                          </Link>
+                        )
+                      }
+                    )
                   )}
                 </PostFullTags>
                 <PostFullTitle className="post-full-title">{post.frontmatter.title}</PostFullTitle>

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -195,11 +195,12 @@ const PageTemplate = ({ data, pageContext, location }: PageTemplateProps) => {
                   {post.frontmatter.tags && post.frontmatter.tags.length > 0 && config.showAllTags && (
                     post.frontmatter.tags.map(
                       function(t){
-                        return (
+                        return ([
                           <Link to={`/tags/${_.kebabCase(t)}/`}>
-                            {t}&nbsp;
-                          </Link>
-                        )
+                            {t}
+                          </Link>,
+                          <b>&nbsp;</b>,
+                        ])
                       }
                     )
                   )}

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -197,7 +197,7 @@ const PageTemplate = ({ data, pageContext, location }: PageTemplateProps) => {
                       function(t){
                         return (
                           <Link to={`/tags/${_.kebabCase(t)}/`}>
-                            {t}&nbsp; 
+                            {t}&nbsp;
                           </Link>
                         )
                       }

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -192,7 +192,7 @@ const PageTemplate = ({ data, pageContext, location }: PageTemplateProps) => {
             <article css={[PostFull, !post.frontmatter.image && NoImage]}>
               <PostFullHeader className="post-full-header">
                 <PostFullTags className="post-full-tags">
-                  {post.frontmatter.tags && post.frontmatter.tags.length > 0 && (
+                  {post.frontmatter.tags && post.frontmatter.tags.length > 0 && config.showAllTags && (
                     post.frontmatter.tags.map(
                       function(t){
                         return (
@@ -202,6 +202,11 @@ const PageTemplate = ({ data, pageContext, location }: PageTemplateProps) => {
                         )
                       }
                     )
+                  )}
+                  {post.frontmatter.tags && post.frontmatter.tags.length > 0 && !config.showAllTags && (
+                    <Link to={`/tags/${_.kebabCase(post.frontmatter.tags[0])}/`}>
+                      {post.frontmatter.tags[0]}
+                    </Link>
                   )}
                 </PostFullTags>
                 <PostFullTitle className="post-full-title">{post.frontmatter.title}</PostFullTitle>

--- a/src/website-config.ts
+++ b/src/website-config.ts
@@ -46,6 +46,11 @@ export interface WebsiteConfig {
    * Appears alongside the footer, after the credits
    */
   footer?: string;
+  /**
+   * Shows all post tags in main index view and post view if true
+   * Otherwise only shows first (primary) tag
+   */
+  showAllTags: boolean;
 }
 
 const config: WebsiteConfig = {
@@ -63,6 +68,7 @@ const config: WebsiteConfig = {
   mailchimpEmailFieldName: 'MERGE0',
   googleSiteVerification: 'GoogleCode',
   footer: 'is based on Gatsby Casper',
+  showAllTags: true,
 };
 
 export default config;


### PR DESCRIPTION
## Context
Was using this great little Gatsby starter for my personal blog, and wanted to have all tags show up for the main index view and individual post view. Made some changes to my fork and figured it might be a desirable option for others using this starter

## Changes
- Index view shows all tags for posts in the listview
- Detailed post view shows all tags for that post above the title
- Added a config flag `showAllTags` which can be unset to enable the previous behaviour (only the first tag is shown)

![image](https://user-images.githubusercontent.com/7781075/133202741-59022b52-d600-4535-973a-fb2eaa233740.png)
