### PR TITLE
Fix pageQuery in author.tsx

### DIFF
--- a/src/templates/author.tsx
+++ b/src/templates/author.tsx
@@ -192,8 +192,8 @@ const Author = ({ data, location }: AuthorTemplateProps) => {
 
 export const pageQuery = graphql`
   query ($author: String) {
-    authorYaml(id: { eq: $author }) {
-      id
+    authorYaml(name: { eq: $author }) {
+      name
       website
       twitter
       bio


### PR DESCRIPTION
The latest commit replaced `author.id` with `author.name` but missed 2 instances in `author.tsx`. That broke the author page.
I've fixed them and tested locally before making this request.