### PR TITLE
Reference converted yaml id key

### DIFF
--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -34,7 +34,7 @@ interface TagTemplateProps {
     allTagYaml: {
       edges: Array<{
         node: {
-          id: string;
+          yamlId: string;
           description: string;
           image?: any;
         };
@@ -52,7 +52,7 @@ interface TagTemplateProps {
 const Tags = ({ pageContext, data, location }: TagTemplateProps) => {
   const tag = pageContext.tag ? pageContext.tag : '';
   const { edges, totalCount } = data.allMarkdownRemark;
-  const tagData = data.allTagYaml.edges.find(n => n.node.id.toLowerCase() === tag.toLowerCase());
+  const tagData = data.allTagYaml.edges.find(n => n.node.yamlId.toLowerCase() === tag.toLowerCase());
 
   return (
     <IndexLayout>
@@ -127,7 +127,7 @@ export const pageQuery = graphql`
     allTagYaml {
       edges {
         node {
-          id
+          yamlId
           description
           image {
             childImageSharp {


### PR DESCRIPTION
gatsby-transformer-yaml converts 'id' fields to be 'yamlId' since 'id' is a reserved internal keyword for Gatsby.

See #115 for a detail explanation.

We should probably rename the yaml field from `id` to something else (e.g. `name`) rather than just let the plugin rename it for us since that's a bit confusing. Just wanted to get this PR out here for now to get things going.